### PR TITLE
Removing hard coded references to Serial interface

### DIFF
--- a/BPLib.cpp
+++ b/BPLib.cpp
@@ -1,7 +1,7 @@
 /*
   BPLib.cpp - Library for communication with RN-42 HID Bluetooth module
   Created by Basel Al-Rudainy, 6 april 2013.
-  
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -15,155 +15,204 @@
 #include "Arduino.h"
 #include "BPLib.h"
 
-BPLib::BPLib(){
-pinMode(7,INPUT);
-digitalWrite(7,LOW);
+BPLib::BPLib(Stream &port, int pin) {
+  this->serialInterface = &port;
+  if (pin > -1) {
+    statusPin = pin;
+  }
 }
 
 byte BPLib::begin(char BP_Mode[], char BP_Type[])
 {
-Serial1.begin(115200);
-Serial1.print(BP_MODE_COMMAND);
-  if (get(BP_STAT_CMD, (byte)5)!=1) {
+  serialInterface->print(BP_MODE_COMMAND);
+  if (get(BP_STAT_CMD, (byte)5) != 1) {
     return (byte)0;
   }//if
-  
-  Serial1.print(BP_Mode);
-  if (get(BP_STAT_ACK, (byte)5)!=1) {
+
+  serialInterface->print(BP_Mode);
+  if (get(BP_STAT_ACK, (byte)5) != 1) {
     return (byte)0;
   }//if
-  if(strcmp(BP_Type,BP_SPP_SPP)>0){
-  Serial1.print(BP_Type);
-  if (get(BP_STAT_ACK, (byte)5)!=1) {
-    return (byte)0;
-  }//if
+  if (strcmp(BP_Type, BP_SPP_SPP) > 0) {
+    serialInterface->print(BP_Type);
+    if (get(BP_STAT_ACK, (byte)5) != 1) {
+      return (byte)0;
+    }//if
   }
-  Serial1.print(BP_REBOOT);
-  if (get(BP_STAT_REBOOT, (byte)9)!=1) {
+  serialInterface->print(BP_REBOOT);
+  if (get(BP_STAT_REBOOT, (byte)9) != 1) {
     return (byte)0;
   }//if
   delay(1000); //Delay (Bluetooth boot-up)
 
-return (byte)1;
+  return (byte)1;
 }
 
 byte BPLib::sendCmd(char BP_CMD[])
 {
-  Serial1.print(BP_MODE_COMMAND);
-  if (get(BP_STAT_CMD, (byte)5)!=1) {
+  serialInterface->print(BP_MODE_COMMAND);
+  if (get(BP_STAT_CMD, (byte)5) != 1) {
     return (byte)0;
   }//if
-  Serial1.print(BP_CMD);
-  if (get(BP_STAT_ACK, (byte)5)!=1) {
+  serialInterface->print(BP_CMD);
+  if (get(BP_STAT_ACK, (byte)5) != 1) {
     return (byte)0;
   }//if
-  Serial1.print(BP_MODE_EXITCOMMAND);
-  if (get(BP_STAT_END, (byte)5)!=1) {
+  serialInterface->print(BP_MODE_EXITCOMMAND);
+  if (get(BP_STAT_END, (byte)5) != 1) {
     return (byte)0;
   }//if
   return (byte)1;
 }
 
-byte BPLib::readRaw(){
-return Serial1.read();
+byte BPLib::readRaw() {
+  return serialInterface->read();
 }
-int BPLib::available(){
-return Serial1.available();
+int BPLib::available() {
+  return serialInterface->available();
 }
 
-byte BPLib::get(char BP_STAT[],byte strlen)
+byte BPLib::get(char BP_STAT[], byte strlen)
 {
-char buffer[strlen + 1];
-  while (Serial1.available() <= (strlen-1)) {};
-    int count = 0;
-    while (Serial1.available() > 0) {
-      buffer[count]=(char)Serial1.read();
-      count++;
-    }//while
-  buffer[strlen]=0;
-    //Serial.print(buffer);//DEBUG
-    if (strcmp(buffer,BP_STAT)==0) {
-      return (byte)1;
-    }//if
-    else {
-      return (byte)0;
-    }//else
+  char buffer[strlen + 1];
+  while (serialInterface->available() <= (strlen - 1)) {};
+  int count = 0;
+  while (serialInterface->available() > 0) {
+    buffer[count] = (char)serialInterface->read();
+    count++;
+  }//while
+  buffer[strlen] = 0;
+  //serialInterface->print(buffer);//DEBUG
+  if (strcmp(buffer, BP_STAT) == 0) {
+    return (byte)1;
+  }//if
+  else {
+    return (byte)0;
+  }//else
 }//get
 
 
-void BPLib::keyboardPress(byte BP_KEY,byte BP_MOD){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x9); //Length byte
-Serial1.write((byte)0x1); //Descriptor byte
-Serial1.write(BP_MOD); //Modifier byte
-Serial1.write((byte)0x00); //-
-Serial1.write(BP_KEY); //Send KEY
-for(byte i = 0;i<5;i++){ //Send five zero bytes
-Serial1.write((byte)0x00);
-}
+void BPLib::keyboardPress(byte BP_KEY, byte BP_MOD) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x9); //Length byte
+  serialInterface->write((byte)0x1); //Descriptor byte
+  serialInterface->write(BP_MOD); //Modifier byte
+  serialInterface->write((byte)0x00); //-
+  serialInterface->write(BP_KEY); //Send KEY
+  for (byte i = 0; i < 5; i++) { //Send five zero bytes
+    serialInterface->write((byte)0x00);
+  }
 
 }
 
-void BPLib::keyboardReleaseAll(){
-keyboardPress((byte)0x00,BP_MOD_NOMOD);
+void BPLib::keyboardReleaseAll() {
+  keyboardPress((byte)0x00, BP_MOD_NOMOD);
 }
 
-void BPLib::mouseClick(byte BP_BUTTON){
-mousePress(BP_BUTTON);
-mouseReleaseAll();
+void BPLib::mouseClick(byte BP_BUTTON) {
+  mousePress(BP_BUTTON);
+  mouseReleaseAll();
 }
-void BPLib::mouseMove(signed int BP_X,signed int BP_Y){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x5); //Length byte
-Serial1.write((byte)0x2); //Descriptor byte
-Serial1.write((byte)0x00); //Button byte
-Serial1.write(BP_X);	//(-127 to 127)
-Serial1.write(BP_Y);	//(-127 to 127)
-Serial1.write((byte)0x00);
+void BPLib::mouseMove(signed int BP_X, signed int BP_Y) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x5); //Length byte
+  serialInterface->write((byte)0x2); //Descriptor byte
+  serialInterface->write((byte)0x00); //Button byte
+  serialInterface->write(BP_X);  //(-127 to 127)
+  serialInterface->write(BP_Y); //(-127 to 127)
+  serialInterface->write((byte)0x00);
 
 }
-void BPLib::mousePress(byte BP_BUTTON){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x5); //Length byte
-Serial1.write((byte)0x2); //Descriptor byte
-Serial1.write(BP_BUTTON); //Button byte
-for(byte i = 0;i<3;i++){ //Send three zero bytes
-Serial1.write((byte)0x00);
-}
-}
-
-void BPLib::mouseReleaseAll(){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x5); //Length byte
-Serial1.write((byte)0x2); //Descriptor byte
-for(byte i = 0;i<4;i++){ //Send four zero bytes
-Serial1.write((byte)0x00);
-}
+void BPLib::mousePress(byte BP_BUTTON) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x5); //Length byte
+  serialInterface->write((byte)0x2); //Descriptor byte
+  serialInterface->write(BP_BUTTON); //Button byte
+  for (byte i = 0; i < 3; i++) { //Send three zero bytes
+    serialInterface->write((byte)0x00);
+  }
 }
 
-void BPLib::mouseWheel(signed int BP_WHEEL){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x5); //Length byte
-Serial1.write((byte)0x2); //Descriptor byte
-for(byte i = 0;i<3;i++){ //Send three zero bytes
-Serial1.write((byte)0x00);
-}
-Serial1.write(BP_WHEEL); //Wheel byte (-127 to 127)
+void BPLib::mouseReleaseAll() {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x5); //Length byte
+  serialInterface->write((byte)0x2); //Descriptor byte
+  for (byte i = 0; i < 4; i++) { //Send four zero bytes
+    serialInterface->write((byte)0x00);
+  }
 }
 
-byte BPLib::changeName(char BP_NAME[]){
- Serial1.print(BP_MODE_COMMAND);
-  if (get(BP_STAT_CMD, (byte)5)!=1) {
+void BPLib::mouseWheel(signed int BP_WHEEL) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x5); //Length byte
+  serialInterface->write((byte)0x2); //Descriptor byte
+  for (byte i = 0; i < 3; i++) { //Send three zero bytes
+    serialInterface->write((byte)0x00);
+  }
+  serialInterface->write(BP_WHEEL); //Wheel byte (-127 to 127)
+}
+
+void BPLib::volumeUp() {
+  sendConsumerCommand((byte)0x10, (byte)0x00);
+}
+
+void BPLib::volumeDown() {
+  sendConsumerCommand((byte)0x20, (byte)0x00);
+}
+
+void BPLib::muteAudio() {
+  sendConsumerCommand((byte)0x40, (byte)0x00);
+}
+
+void BPLib::playPause() {
+  sendConsumerCommand((byte)0x80, (byte)0x00);
+}
+
+void BPLib::nextTrack() {
+  sendConsumerCommand((byte)0x00, (byte)0x01);
+}
+
+void BPLib::prevTrack() {
+  sendConsumerCommand((byte)0x00, (byte)0x02);
+}
+
+void BPLib::stopAudio() {
+  sendConsumerCommand((byte)0x00, (byte)0x04);
+}
+
+void BPLib::fastForwardAudio() {
+  sendConsumerCommand((byte)0x00, (byte)0x10);
+}
+
+void BPLib::rewindAudio() {
+  sendConsumerCommand((byte)0x00, (byte)0x20);
+}
+
+void BPLib::keyRelease() {
+  sendConsumerCommand((byte)0x00, (byte)0x00);
+}
+
+void BPLib::sendConsumerCommand(byte lowByte, byte highByte) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x3); //Length byte
+  serialInterface->write((byte)0x3); //Descriptor byte
+  serialInterface->write(lowByte); //Key Release LowByte
+  serialInterface->write(highByte); //Key Release HighByte
+}
+
+byte BPLib::changeName(char BP_NAME[]) {
+  serialInterface->print(BP_MODE_COMMAND);
+  if (get(BP_STAT_CMD, (byte)5) != 1) {
     return (byte)0;
   }//if
-  Serial1.print(BP_CHANGE_NAME);
-  Serial1.print(BP_NAME);
-  Serial1.print(F("\r\n"));
-  if (get(BP_STAT_ACK, (byte)5)!=1) {
+  serialInterface->print(BP_CHANGE_NAME);
+  serialInterface->print(BP_NAME);
+  serialInterface->print(F("\r\n"));
+  if (get(BP_STAT_ACK, (byte)5) != 1) {
     return (byte)0;
   }//if
-  Serial1.print(BP_MODE_EXITCOMMAND);
-  if (get(BP_STAT_END, (byte)5)!=1) {
+  serialInterface->print(BP_MODE_EXITCOMMAND);
+  if (get(BP_STAT_END, (byte)5) != 1) {
     return (byte)0;
   }//if
   return (byte)1;
@@ -171,48 +220,52 @@ byte BPLib::changeName(char BP_NAME[]){
 }
 
 
-void BPLib::sendByte(byte rawData){
-Serial1.print(rawData);
+void BPLib::sendByte(byte rawData) {
+  serialInterface->print(rawData);
 }
-void BPLib::sendChar(char rawData){
-Serial1.print(rawData);
+void BPLib::sendChar(char rawData) {
+  serialInterface->print(rawData);
 }
-void BPLib::sendInt(int rawData){
-Serial1.print(rawData);
+void BPLib::sendInt(int rawData) {
+  serialInterface->print(rawData);
 }
-void BPLib::sendFloat(float rawData){
-Serial1.print(rawData);
+void BPLib::sendFloat(float rawData) {
+  serialInterface->print(rawData);
 }
-void BPLib::sendLong(long rawData){
-Serial1.print(rawData);
+void BPLib::sendLong(long rawData) {
+  serialInterface->print(rawData);
 }
-void BPLib::sendString(char rawData[]){
-Serial1.print(rawData);
-}
-
-void BPLib::gameJoyPress(byte BP_ST_BTN, byte BP_ND_BTN){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x6); //Length byte
-Serial1.write((byte)BP_ST_BTN); //First Button byte
-Serial1.write((byte)BP_ND_BTN); //Second Button byte
-for(byte i = 0;i<4;i++){ //Send four zero bytes
-Serial1.write((byte)0x00);
-}
-}
-void BPLib::gameJoyMove(signed int BP_X1,signed int BP_Y1,signed int BP_X2,signed int BP_Y2){
-Serial1.write((byte)0xFD); //Start HID Report
-Serial1.write((byte)0x6); //Length byte
-Serial1.write((byte)BP_GAMEJOY_ST_NOBTN); //First Button byte
-Serial1.write((byte)BP_GAMEJOY_ND_NOBTN); //Second Button byte
-Serial1.write(BP_X1 & 0xFF);	//First X coordinate
-Serial1.write(BP_Y1 & 0xFF);	//First Y coordinate
-Serial1.write(BP_X2 & 0xFF);	//Second X coordinate
-Serial1.write(BP_Y2 & 0xFF);	//Second Y coordinate
-}
-void BPLib::gameJoyReleaseAll(){
-gameJoyPress(BP_GAMEJOY_ST_NOBTN, BP_GAMEJOY_ND_NOBTN);
+void BPLib::sendString(char rawData[]) {
+  serialInterface->print(rawData);
 }
 
-byte BPLib::connected(){
-return digitalRead(7);
+void BPLib::gameJoyPress(byte BP_ST_BTN, byte BP_ND_BTN) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x6); //Length byte
+  serialInterface->write((byte)BP_ST_BTN); //First Button byte
+  serialInterface->write((byte)BP_ND_BTN); //Second Button byte
+  for (byte i = 0; i < 4; i++) { //Send four zero bytes
+    serialInterface->write((byte)0x00);
+  }
+}
+void BPLib::gameJoyMove(signed int BP_X1, signed int BP_Y1, signed int BP_X2, signed int BP_Y2) {
+  serialInterface->write((byte)0xFD); //Start HID Report
+  serialInterface->write((byte)0x6); //Length byte
+  serialInterface->write((byte)BP_GAMEJOY_ST_NOBTN); //First Button byte
+  serialInterface->write((byte)BP_GAMEJOY_ND_NOBTN); //Second Button byte
+  serialInterface->write(BP_X1 & 0xFF); //First X coordinate
+  serialInterface->write(BP_Y1 & 0xFF); //First Y coordinate
+  serialInterface->write(BP_X2 & 0xFF); //Second X coordinate
+  serialInterface->write(BP_Y2 & 0xFF); //Second Y coordinate
+}
+void BPLib::gameJoyReleaseAll() {
+  gameJoyPress(BP_GAMEJOY_ST_NOBTN, BP_GAMEJOY_ND_NOBTN);
+}
+
+int BPLib::connected() {
+  if (statusPin > -1) {
+    return digitalRead(statusPin);
+  } else {
+    return -1;
+  }
 }

--- a/BPLib.h
+++ b/BPLib.h
@@ -1,7 +1,7 @@
 /*
   BPLib.h - Library for communication with RN-42 HID Bluetooth module
   Created by Basel Al-Rudainy, 6 april 2013.
-  
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -123,31 +123,48 @@
 class BPLib
 {
 public:
-BPLib();
-byte begin(char BP_Mode[], char BP_Type[]);
-byte sendCmd(char BP_CMD[]);
-void sendByte(byte rawData);
-void sendChar(char rawData);
-void sendInt(int rawData);
-void sendFloat(float rawData);
-void sendLong(long rawData);
-void sendString(char rawData[]);
-byte readRaw();
-int available();
-void keyboardPrint(char BP_MSG[]);
-void keyboardPress(byte BP_KEY,byte BP_MOD);
-void keyboardReleaseAll();
-void mouseClick(byte BP_BUTTON);
-void mouseMove(signed int BP_X,signed int BP_Y);
-void mouseWheel(signed int BP_WHEEL);
-void mousePress(byte BP_BUTTON);
-void mouseReleaseAll();
-void gameJoyPress(byte BP_ST_BTN, byte BP_ND_BTN);
-void gameJoyMove(signed int BP_X1,signed int BP_Y1,signed int BP_X2,signed int BP_Y2);
-void gameJoyReleaseAll();
-byte connected();
-byte changeName(char BP_NAME[]);
+  BPLib(Stream &port, int pin = -1);
+  byte begin(char BP_Mode[], char BP_Type[]);
+  byte sendCmd(char BP_CMD[]);
+  void sendByte(byte rawData);
+  void sendChar(char rawData);
+  void sendInt(int rawData);
+  void sendFloat(float rawData);
+  void sendLong(long rawData);
+  void sendString(char rawData[]);
+  byte readRaw();
+  int available();
+  //Keyboard
+  void keyboardPrint(char BP_MSG[]);
+  void keyboardPress(byte BP_KEY,byte BP_MOD);
+  void keyboardReleaseAll();
+  // Mouse
+  void mouseClick(byte BP_BUTTON);
+  void mouseMove(signed int BP_X,signed int BP_Y);
+  void mouseWheel(signed int BP_WHEEL);
+  void mousePress(byte BP_BUTTON);
+  void mouseReleaseAll();
+  // Consumer
+  void volumeUp();
+  void volumeDown();
+  void muteAudio();
+  void playPause();
+  void nextTrack();
+  void prevTrack();
+  void stopAudio();
+  void fastForwardAudio();
+  void rewindAudio();
+  void keyRelease();
+  void sendConsumerCommand(byte lowByte, byte highByte);
+  // GamePad
+  void gameJoyPress(byte BP_ST_BTN, byte BP_ND_BTN);
+  void gameJoyMove(signed int BP_X1,signed int BP_Y1,signed int BP_X2,signed int BP_Y2);
+  void gameJoyReleaseAll();
+  int connected();
+  byte changeName(char BP_NAME[]);
 private:
-byte get(char BP_STAT[], byte strlen);
+  Stream *serialInterface;
+  int statusPin;
+  byte get(char BP_STAT[], byte strlen);
 };
 #endif

--- a/examples/HID_KEYBOARD/HID_KEYBOARD.ino
+++ b/examples/HID_KEYBOARD/HID_KEYBOARD.ino
@@ -2,32 +2,46 @@
 Bluetooth HID Keyboard - example
 This example illustrates the different ways you can send keys/keystrokes with the HID keyboard protocol.
 This sketch will print the following on the recieving device: lesab (mirrored basel).
+
+This example is using the ESP8266 software serial
 */
 
 
 #include <BPLib.h>
+#include <SoftwareSerial.h>
 
-BPLib BPMod;
+#define RX_PIN D2 // connect to TXD of module
+#define TX_PIN D1 // connect to RXD of module (logic level 3.3v!)
+
+SoftwareSerial swSer(RX_PIN, TX_PIN, false, 128);
+
+BPLib *BPMod;
 void setup(){
-BPMod.begin(BP_MODE_HID,BP_HID_KEYBOARD);   //Begin HID Mode with HID KEYBOARD AS TYPE
-  
+  Serial.begin(115200);
+  swSer.begin(115200);
+
+  BPMod = new BPLib(swSer);
+
+  BPMod->begin(BP_MODE_HID,BP_HID_KEYBOARD);   //Begin HID Mode with HID KEYBOARD AS TYPE
+
 }
 
 void loop(){
+  Serial.println("loop");
   delay(5000);    //Delay 5 seconds between each loop (Not nec.)
-  BPMod.sendString("b");  //Send a string (will be recieved as keystroke)
-  BPMod.keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD); //Send Scan code (KEY, MODEFIER key)
-  BPMod.keyboardReleaseAll(); //Release all keys
-  BPMod.sendString("a");
-  BPMod.keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
-  BPMod.keyboardReleaseAll();
-  BPMod.sendString("s");
-  BPMod.keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
-  BPMod.keyboardReleaseAll();
-  BPMod.sendString("e");
-  BPMod.keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
-  BPMod.keyboardReleaseAll();
-  BPMod.sendString("l");
-  BPMod.keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
-  BPMod.keyboardReleaseAll();
+  BPMod->sendString("b");  //Send a string (will be recieved as keystroke)
+  BPMod->keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD); //Send Scan code (KEY, MODEFIER key)
+  BPMod->keyboardReleaseAll(); //Release all keys
+  BPMod->sendString("a");
+  BPMod->keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
+  BPMod->keyboardReleaseAll();
+  BPMod->sendString("s");
+  BPMod->keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
+  BPMod->keyboardReleaseAll();
+  BPMod->sendString("e");
+  BPMod->keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
+  BPMod->keyboardReleaseAll();
+  BPMod->sendString("l");
+  BPMod->keyboardPress(BP_KEY_LEFT_ARROW,BP_MOD_NOMOD);
+  BPMod->keyboardReleaseAll();
 }

--- a/examples/HID_MOUSE/HID_MOUSE.ino
+++ b/examples/HID_MOUSE/HID_MOUSE.ino
@@ -7,17 +7,19 @@ This example illustrated how the library can be used to make mouse movements and
 
 #include <BPLib.h>
 
-BPLib BPMod;
+BPLib *BPMod;
 void setup(){
-BPMod.begin(BP_MODE_HID,BP_HID_MOUSE);
-  
+  Serial.begin(115200);
+  BPMod = new BPLib(swSer);
+  BPMod->begin(BP_MODE_HID,BP_HID_MOUSE);
+
 }
 
 void loop(){
   delay(1000);
   for(signed int i=-127;i<127;i++){
-    BPMod.mouseMove(i,i);
+    BPMod->mouseMove(i,i);
     delay(100);
   }
-  BPMod.mouseClick(BP_MOUSE_BTN_LEFT);
+  BPMod->mouseClick(BP_MOUSE_BTN_LEFT);
 }

--- a/examples/HID_MOUSE_WHEEL/HID_MOUSE_WHEEL.ino
+++ b/examples/HID_MOUSE_WHEEL/HID_MOUSE_WHEEL.ino
@@ -7,15 +7,17 @@ This example illustrated the use of the Bluetooth Mouse Wheel (Scrolling).
 
 #include <BPLib.h>
 
-BPLib BPMod;
+BPLib *BPMod;
 void setup(){
-BPMod.begin(BP_MODE_HID,BP_HID_MOUSE);
+  Serial.begin(115200);
+  BPMod = new BPLib(swSer);
+  BPMod->begin(BP_MODE_HID,BP_HID_MOUSE);
 }
 
 void loop(){
   delay(5000);
   for(signed int i=-5;i<5;i++){
-    BPMod.mouseWheel(i);
+    BPMod->mouseWheel(i);
     delay(100);
   }
 }

--- a/examples/SPP_SEND_REC_MSG/SPP_SEND_REC_MSG.ino
+++ b/examples/SPP_SEND_REC_MSG/SPP_SEND_REC_MSG.ino
@@ -8,25 +8,32 @@ This example illustrates the use of the bluetooth serial protocol.
 
 #include <BPLib.h>
 
-BPLib BPMod;
+BPLib *BPMod;
 int count = 0;
 void setup(){
-  BPMod.begin(BP_MODE_SPP,BP_SPP_SPP); //Bluetooth Serial Mode
-  BPMod.changeName("BlueNar_One");    //Change bluetooth name (appears on devices searching for BT)
-  while(!BPMod.connected()){}; //BlueNar One only! Check if a connection is made
+  Serial.begin(115200);
+
+  // The 7 pin was something that was previously hard coded into the library, its state gets read by the connected method
+  // I'm not really sure what it does :)
+  // I guess it has something to do with "BlueNar One only" comments
+  pinMode(7, INPUT);
+  BPMod = new BPLib(swSer, 7);
+  BPMod->begin(BP_MODE_SPP,BP_SPP_SPP); //Bluetooth Serial Mode
+  BPMod->changeName("BlueNar_One");    //Change bluetooth name (appears on devices searching for BT)
+  while(!BPMod->connected()){}; //BlueNar One only! Check if a connection is made
 }
 
 void loop(){
-  if(BPMod.connected()){    //BlueNar One only! if connected then proceed
- if(BPMod.available()>0){   //Check if data is available
-  BPMod.readRaw();    //Read the data (just to empty the buffer)
+  if(BPMod->connected()){    //BlueNar One only! if connected then proceed
+ if(BPMod->available()>0){   //Check if data is available
+  BPMod->readRaw();    //Read the data (just to empty the buffer)
   count++;
-  BPMod.sendString("Count: ");  //Send a string
-  BPMod.sendInt(count);         //Send a integer
-  BPMod.sendChar('\n');         //Send character
+  BPMod->sendString("Count: ");  //Send a string
+  BPMod->sendInt(count);         //Send a integer
+  BPMod->sendChar('\n');         //Send character
  }
   }
   else{
-    while(!BPMod.connected()){};  //BlueNar One only! - If disconnected wait for a new connection
+    while(!BPMod->connected()){};  //BlueNar One only! - If disconnected wait for a new connection
   }
 }


### PR DESCRIPTION
Nice library! I know its pretty old at this stage but I thought I'd raise a PR of the work I've done with it.

The main change is replace the hardcoding of the Serial interface. The user of the library should now pass in a Serial interface as part of the constructor.  This should allow users to use whatever serial interface they want, including software ones.

I have been succesful in testing the RN42 with the hardware serial though on my esp8266, If I open the serial monitor i see the $$$ are sent, but the keyboard commands are not sent to my phone when i connect, so this may need further testing (it could be my wiring)


List of changes:
- Made the serial connection that is used a paraemeter of the constructor. (succesfully tested with Software serial, hasn't worked with HW serial for me yet, more debugging needed)
- Pulling in changes from Brandon Bluetooth Button project: https://conoroneill.net/introducing-the-bandon-bluetooth-button-bbb-using-rn42-hid/
- Updated HID_Keyboard example to use software serial
- Updated other examples to compile